### PR TITLE
Avoid Unnecessary Release Assets Downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# IDEA configs
+.idea/

--- a/Luatrauma.AutoUpdater/LocalVersionInfo.cs
+++ b/Luatrauma.AutoUpdater/LocalVersionInfo.cs
@@ -1,0 +1,66 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Luatrauma.AutoUpdater;
+
+using System;
+using System.IO;
+
+public record LocalVersionInfo(
+    [property: JsonPropertyName("updated_at")]
+    string UpdatedAt
+)
+{
+    public const string DefaultFileName = "Luatrauma.AutoUpdater.LocalVersionInfo.json";
+
+    public static async Task<LocalVersionInfo?> RetrieveLocalVersionInfoAsync(string workingDirectory)
+    {
+        try
+        {
+            var configFilePath = Path.Combine(workingDirectory, DefaultFileName);
+            var configFileStream = new FileStream(configFilePath, FileMode.Open);
+
+            var versionInfo = await JsonSerializer.DeserializeAsync<LocalVersionInfo>(configFileStream);
+
+            if (versionInfo == null)
+            {
+                Logger.Log($"Failed to deserialize {DefaultFileName}", ConsoleColor.Red);
+            }
+
+            return versionInfo;
+        }
+        catch (UnauthorizedAccessException e)
+        {
+            Logger.Log($"Failed to retrieve local version info: {e.Message}");
+            return null;
+        }
+        catch (FileNotFoundException e)
+        {
+            Logger.Log($"Failed to retrieve local version info: {e.Message}");
+            return null;
+        }
+    }
+
+    public static Task<LocalVersionInfo?> RetrieveLocalVersionInfoAsync()
+    {
+        return RetrieveLocalVersionInfoAsync(Directory.GetCurrentDirectory());
+    }
+
+    /**
+     * Note: may throw
+     */
+    public async Task WriteToFileAsync(string filePath)
+    {
+        var jsonContent = JsonSerializer.Serialize(this);
+
+        await File.WriteAllTextAsync(filePath, jsonContent);
+    }
+
+    /**
+     * Note: may throw
+     */
+    public Task WriteToFileAsync()
+    {
+        return WriteToFileAsync(Path.Combine(Directory.GetCurrentDirectory(), DefaultFileName));
+    }
+}

--- a/Luatrauma.AutoUpdater/RemoteVersionInfo.cs
+++ b/Luatrauma.AutoUpdater/RemoteVersionInfo.cs
@@ -1,0 +1,63 @@
+﻿using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Luatrauma.AutoUpdater;
+
+public record RemoteVersionInfo(
+    [property: JsonPropertyName("updated_at")]
+    string UpdatedAt
+)
+{
+    /**
+     * Note: may throw
+     * <returns>null if deserialization failed</returns>
+     */
+    public static async Task<RemoteVersionInfo?> FetchRemoteVersionInfoAsync()
+    {
+        // you need to use product specific http client (with user-agent header), otherwise the request will be rejected
+        using var httpClient = Utils.CreateProductSpecificHttpClient();
+
+        var responseMessage = await httpClient.GetAsync(
+            "https://api.github.com/repos/evilfactory/LuaCsForBarotrauma/releases/latest"
+        );
+
+        if (responseMessage.StatusCode == HttpStatusCode.OK)
+        {
+            RemoteVersionInfo? remoteVersionInfo;
+            try
+            {
+                remoteVersionInfo = await JsonSerializer.DeserializeAsync<RemoteVersionInfo>(
+                    await responseMessage.Content.ReadAsStreamAsync()
+                );
+            }
+            catch (Exception e)
+            {
+                remoteVersionInfo = null;
+            }
+
+            if (remoteVersionInfo == null)
+            {
+                Logger.Log("Failed to deserialize GitHub API response", ConsoleColor.Red);
+            }
+
+            return remoteVersionInfo;
+        }
+
+        Logger.Log(
+            $"GitHub API response is NOT OK:\n{responseMessage}\nwith content:\n{await responseMessage.Content.ReadAsStringAsync()}");
+
+        if (responseMessage.StatusCode == HttpStatusCode.Forbidden)
+        {
+            Logger.Log("GitHub API responses 403; assume rate limit exceeded");
+
+            return null;
+        }
+
+        Logger.Log(
+            $"Encountered unexpected response status code: {responseMessage.StatusCode}; review is recommended",
+            ConsoleColor.Yellow
+        );
+        throw new Exception($"Unexpected response status code: {responseMessage.StatusCode}");
+    }
+}

--- a/Luatrauma.AutoUpdater/Updater.cs
+++ b/Luatrauma.AutoUpdater/Updater.cs
@@ -28,117 +28,188 @@ namespace Luatrauma.AutoUpdater
         {
             Logger.Log("Starting update...");
 
-            string patchUrl = null;
-            if (OperatingSystem.IsWindows())
-            {
-                patchUrl = "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_windows_client.zip";
-            }
-            else if (OperatingSystem.IsLinux())
-            {
-                patchUrl = "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_linux_client.zip";
-            }
-            else if (OperatingSystem.IsMacOS())
-            {
-                patchUrl = "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_mac_client.zip";
-            }
+            Logger.Log("Loading local version info...");
+            var localVersionInfo = await LocalVersionInfo.RetrieveLocalVersionInfoAsync();
+            Logger.Log(localVersionInfo != null
+                ? $"Local version info loaded:\n{localVersionInfo}"
+                : "Local version info is NOT loaded");
 
-            if (patchUrl == null)
-            {
-                Logger.Log("Unsupported operating system.");
-                return;
-            }
-
-            string tempFolder = Path.Combine(Directory.GetCurrentDirectory(), "Luatrauma.AutoUpdater.Temp");
-            string patchZip = Path.Combine(tempFolder, "patch.zip");
-            string extractionFolder = Path.Combine(tempFolder, "Extracted");
-
-            Logger.Log($"Downloading patch zip from {patchUrl}");
-
+            Logger.Log("Loading remote version info...");
+            RemoteVersionInfo? remoteVersionInfo = null;
             try
             {
-                using var client = new HttpClient();
-
-                byte[] fileBytes = await client.GetByteArrayAsync(patchUrl);
-
-                await File.WriteAllBytesAsync(patchZip, fileBytes);
+                remoteVersionInfo = await RemoteVersionInfo.FetchRemoteVersionInfoAsync();
+                Logger.Log(remoteVersionInfo != null
+                    ? $"Remote version info loaded:\n{remoteVersionInfo}"
+                    : "Remote version info is NOT loaded");
             }
             catch (Exception e)
             {
-                Logger.Log($"Failed to download patch zip: {e.Message}");
-                return;
+                Logger.Log($"Error encountered while fetching remote version info: {e.Message}");
             }
 
-            Logger.Log($"Downloaded patch zip to {patchZip}");
-
-            try
+            if (localVersionInfo != null && remoteVersionInfo != null &&
+                localVersionInfo.UpdatedAt == remoteVersionInfo.UpdatedAt)
             {
-                if (Directory.Exists(extractionFolder))
-                {
-                    Directory.Delete(extractionFolder, true);
-                }
-                Directory.CreateDirectory(extractionFolder);
-
-                ZipFile.ExtractToDirectory(patchZip, extractionFolder, true);
-
-            }
-            catch (Exception e)
-            {
-                Logger.Log($"Failed to extract patch zip: {e.Message}");
-                return;
-            }
-
-            Logger.Log($"Extracted patch zip to {Directory.GetCurrentDirectory()}");
-
-            Logger.Log($"Applying patch...");
-
-            // Verify that the dll version is the same as the current one
-            string currentDll = Path.Combine(Directory.GetCurrentDirectory(), "Barotrauma.dll");
-            string newDll = Path.Combine(extractionFolder, "Barotrauma.dll");
-
-            if (!File.Exists(currentDll))
-            {
-                Logger.Log("Failed to find the current Barotrauma.dll", ConsoleColor.Red);
-                return;
-            }
-
-            if (!File.Exists(newDll))
-            {
-                Logger.Log("Failed to find the new Barotrauma.dll", ConsoleColor.Red);
-                return;
-            }
-
-            // Grab the version of the current dll
-            var currentVersion = FileVersionInfo.GetVersionInfo(currentDll);
-            var newVersion = FileVersionInfo.GetVersionInfo(newDll);
-
-            if (currentVersion == null || newVersion == null)
-            {
-                Logger.Log("Failed to get version info for the dlls");
-                return;
-            }
-
-            if (currentVersion.FileVersion == newVersion.FileVersion)
-            {
-                Logger.Log($"The patch is compatible with the current game version {newVersion.FileVersion}.");
+                Logger.Log("Both version info contain the same updated_at attribute, skipping patch fetching");
             }
             else
             {
-                Logger.Log($"The patch is not compatible with the current game version {currentVersion.FileVersion} -> {newVersion.FileVersion}, aborting.");
+                string patchUrl = null;
+                if (OperatingSystem.IsWindows())
+                {
+                    patchUrl =
+                        "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_windows_client.zip";
+                }
+                else if (OperatingSystem.IsLinux())
+                {
+                    patchUrl =
+                        "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_linux_client.zip";
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    patchUrl =
+                        "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_mac_client.zip";
+                }
 
-                Logger.Log("Theres no patch available for the current game version, the game will be launched without the patch, if there was a new game update please wait until a new patch is released.", ConsoleColor.Yellow);
+                if (patchUrl == null)
+                {
+                    Logger.Log("Unsupported operating system.");
+                    return;
+                }
 
-                await Task.Delay(8000);
+                string tempFolder = Path.Combine(Directory.GetCurrentDirectory(), "Luatrauma.AutoUpdater.Temp");
+                string patchZip = Path.Combine(tempFolder, "patch.zip");
+                string extractionFolder = Path.Combine(tempFolder, "Extracted");
 
-                return;
-            }
+                Logger.Log($"Downloading patch zip from {patchUrl}");
 
-            CopyFilesRecursively(extractionFolder, Directory.GetCurrentDirectory());
+                try
+                {
+                    using var client = new HttpClient();
 
-            Logger.Log("Patch applied.");
+                    byte[] fileBytes = await client.GetByteArrayAsync(patchUrl);
 
-            if (File.Exists("luacsversion.txt")) // Workshop stuff, get rid of it so it doesn't interfere
-            {
-                File.Delete("luacsversion.txt");
+                    await File.WriteAllBytesAsync(patchZip, fileBytes);
+                }
+                catch (Exception e)
+                {
+                    Logger.Log($"Failed to download patch zip: {e.Message}");
+                    return;
+                }
+
+                Logger.Log($"Downloaded patch zip to {patchZip}");
+
+                try
+                {
+                    if (Directory.Exists(extractionFolder))
+                    {
+                        Directory.Delete(extractionFolder, true);
+                    }
+
+                    Directory.CreateDirectory(extractionFolder);
+
+                    ZipFile.ExtractToDirectory(patchZip, extractionFolder, true);
+                }
+                catch (Exception e)
+                {
+                    Logger.Log($"Failed to extract patch zip: {e.Message}");
+                    return;
+                }
+
+                Logger.Log($"Extracted patch zip to {Directory.GetCurrentDirectory()}");
+
+                Logger.Log($"Applying patch...");
+
+                // Verify that the dll version is the same as the current one
+                string currentDll = Path.Combine(Directory.GetCurrentDirectory(), "Barotrauma.dll");
+                string newDll = Path.Combine(extractionFolder, "Barotrauma.dll");
+
+                if (!File.Exists(currentDll))
+                {
+                    Logger.Log("Failed to find the current Barotrauma.dll", ConsoleColor.Red);
+                    return;
+                }
+
+                if (!File.Exists(newDll))
+                {
+                    Logger.Log("Failed to find the new Barotrauma.dll", ConsoleColor.Red);
+                    return;
+                }
+
+                // Grab the version of the current dll
+                var currentVersion = FileVersionInfo.GetVersionInfo(currentDll);
+                var newVersion = FileVersionInfo.GetVersionInfo(newDll);
+
+                if (currentVersion == null || newVersion == null)
+                {
+                    Logger.Log("Failed to get version info for the dlls");
+                    return;
+                }
+
+                if (currentVersion.FileVersion == newVersion.FileVersion)
+                {
+                    Logger.Log($"The patch is compatible with the current game version {newVersion.FileVersion}.");
+                }
+                else
+                {
+                    Logger.Log(
+                        $"The patch is not compatible with the current game version {currentVersion.FileVersion} -> {newVersion.FileVersion}, aborting.");
+
+                    Logger.Log(
+                        "Theres no patch available for the current game version, the game will be launched without the patch, if there was a new game update please wait until a new patch is released.",
+                        ConsoleColor.Yellow);
+
+                    await Task.Delay(8000);
+
+                    return;
+                }
+
+                CopyFilesRecursively(extractionFolder, Directory.GetCurrentDirectory());
+
+                Logger.Log("Patch applied.");
+
+                if (File.Exists("luacsversion.txt")) // Workshop stuff, get rid of it so it doesn't interfere
+                {
+                    File.Delete("luacsversion.txt");
+                }
+
+                // update local version info
+                if (remoteVersionInfo == null)
+                {
+                    Logger.Log("Remote version info is null, deleting local version info...");
+
+                    try
+                    {
+                        File.Delete(LocalVersionInfo.DefaultFileName);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Failed to delete local version info: {e.Message}");
+                    }
+                }
+                else
+                {
+                    Logger.Log("Updating local version info...");
+
+                    var newLocalVersionInfo = new LocalVersionInfo(
+                        UpdatedAt: remoteVersionInfo.UpdatedAt
+                    );
+
+                    try
+                    {
+                        await newLocalVersionInfo.WriteToFileAsync();
+
+                        Logger.Log("Updated local version info successfully written");
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log(
+                            $"Error encountered while writing updated local version info to file: {e.Message}",
+                            ConsoleColor.Red
+                        );
+                    }
+                }
             }
 
             Logger.Log("Update completed.");

--- a/Luatrauma.AutoUpdater/Utils.cs
+++ b/Luatrauma.AutoUpdater/Utils.cs
@@ -1,0 +1,13 @@
+﻿namespace Luatrauma.AutoUpdater;
+
+public static class Utils
+{
+    public static HttpClient CreateProductSpecificHttpClient()
+    {
+        var httpClient = new HttpClient();
+        
+        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Luatrauma.AutoUpdater/1.0");
+
+        return httpClient;
+    }
+}


### PR DESCRIPTION
Using github api to access the `updated_at` attribute of the latest release and store the information locally. Compare the locally stored `updated_at` with the latest release's `updated_at` everytime the program runs, if they are the same, skip the update process.

Here's the [API doc](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release).